### PR TITLE
fixed on paste issue with images in chat

### DIFF
--- a/app/components/chat/chatInput.tsx
+++ b/app/components/chat/chatInput.tsx
@@ -69,8 +69,8 @@ const ChatInput = ({
           const syntheticEvent = {
             target: {
               files: [file],
-              preventDefault: () => {},
             },
+            preventDefault: () => {},
           } as unknown as React.ChangeEvent<HTMLInputElement>;
 
           handleFileInputChange(syntheticEvent);


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixes image paste handling in chat input.

- Moves `preventDefault` to correct event scope.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chatInput.tsx</strong><dd><code>Corrects synthetic event structure for image paste handling</code></dd></summary>
<hr>

app/components/chat/chatInput.tsx

<li>Moves <code>preventDefault</code> from <code>target</code> to event object in synthetic event.<br> <li> Ensures pasted images are handled correctly in chat input.


</details>


  </td>
  <td><a href="https://github.com/byarcnine/open-agent-kit-core/pull/98/files#diff-57dc54e1dc3a9daa52dc60e09a594a74e6982e37e96f007e794534285787036d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>