### PR TITLE
allow plugins to define agent independent routes

### DIFF
--- a/app/lib/llm/streamConversation.server.ts
+++ b/app/lib/llm/streamConversation.server.ts
@@ -129,7 +129,6 @@ export const streamConversation = async (
     createMessagePromise,
   ]);
   const { tools: toolsArray, closeMCPs } = tools;
-  console.log(toolsArray);
   return {
     stream: streamText({
       model: model.model,

--- a/app/lib/plugins/plugins.server.ts
+++ b/app/lib/plugins/plugins.server.ts
@@ -76,5 +76,9 @@ export async function getTools(
 }
 
 export const getPluginNameForSlug = (slug: string) => {
+  if (importedPlugins.some((plugin) => plugin.name === slug)) {
+    // this is the actual plugin identifier
+    return slug;
+  }
   return importedPlugins.find((plugin) => plugin.slug === slug)?.name;
 };

--- a/utils/withOAKContext.ts
+++ b/utils/withOAKContext.ts
@@ -22,7 +22,10 @@ export const withOAKContext = serverOnly$(
     return (async (args: LoaderOrActionArgs) => {
       const path = args.request.url.split("/");
       const indexOfPlugin = path.indexOf("plugins");
-      const pluginSlug = path[indexOfPlugin + 1];
+      // UI routes are prefix with /plugins/[pluginSlug|
+      // global routes are prefix with the plugin identifier only
+      const pluginSlug =
+        indexOfPlugin !== -1 ? path[indexOfPlugin + 1] : path[0];
       const pluginSlugWithoutParams = pluginSlug.split("?")[0];
       const pluginName = getPluginNameForSlug(
         pluginSlugWithoutParams,


### PR DESCRIPTION
### **User description**
This will allow plugin to define routes that don't change depending on the agent id. This is useful for callbacks from external services where URLs have to be explicitly whitelisted (e.g Google OAuth)


___

### **PR Type**
enhancement


___

### **Description**
- Enable plugins to define agent-independent (global) routes

- Add support for plugin routes with paths starting with `//`

- Filter and handle global plugin routes in both admin and user contexts

- Minor code cleanup in LLM streaming logic


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>routes.ts</strong><dd><code>Add support for agent-independent (global) plugin routes</code>&nbsp; </dd></summary>
<hr>

app/routes.ts

<li>Allow plugin routes with paths starting with <code>//</code> to be registered as <br>global (agent-independent) routes.<br> <li> Filter out global routes from agent-specific route lists.<br> <li> Add logic to register global plugin routes at the API level.<br> <li> Ensure both admin and user plugin routes can define global endpoints.


</details>


  </td>
  <td><a href="https://github.com/byarcnine/open-agent-kit-core/pull/106/files#diff-48416f61396f9bf0a7795d170670d0ca8e9cb2db642751d5c6949eac5fe7e307">+39/-12</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>streamConversation.server.ts</strong><dd><code>Remove debug logging from LLM streaming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/lib/llm/streamConversation.server.ts

- Remove unnecessary console.log statement for toolsArray.


</details>


  </td>
  <td><a href="https://github.com/byarcnine/open-agent-kit-core/pull/106/files#diff-54263acfee47aed0e93448510642d8ed950bbab160c4526098bd2cd9a24d4396">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>